### PR TITLE
Make merge default load mode

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -9,17 +9,26 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: changed
+        :tags: Load
+
+        Changed default/first load mode to be merge.
+
+
     .. change:: fixed
+        :tags: hook
 
         Same version of Houdini detected twice on Linux because of symlink.
 
 
     .. change:: fixed
+        :tags: hook
 
         Fix apprentice discovery bug on Mac.
 
 
     .. change:: new
+        :tags: doc
 
         Added API reference and release notes.
 

--- a/source/ftrack_connect_pipeline_houdini/constants/asset/modes.py
+++ b/source/ftrack_connect_pipeline_houdini/constants/asset/modes.py
@@ -6,12 +6,12 @@ from ftrack_connect_pipeline_houdini.utils import (
 )
 
 # Load Modes
-IMPORT_MODE = 'import'
 MERGE_MODE = 'merge'
+IMPORT_MODE = 'import'
 OPEN_MODE = 'open'
 
 LOAD_MODES = {
-    IMPORT_MODE: houdini_utils.import_scene,
     MERGE_MODE: houdini_utils.merge_scene,
+    IMPORT_MODE: houdini_utils.import_scene,
     OPEN_MODE: houdini_utils.open_scene,
 }


### PR DESCRIPTION
Resolves : 

* CLICKUP-https://app.clickup.com/t/3rj7pb4

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Make merge default load mode for Houdini loaders

## Test

Test assembler in Houdini, should suggest merge instead of import.
            