### PR TITLE
feat: Backlog/fix houdini exporters

### DIFF
--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -8,6 +8,12 @@ Release Notes
 *************
 
 .. release:: upcoming
+    .. change:: fix
+
+        Fixed UI bugs in Alembic and FBX exporter.
+        Added frame range and take options to FBX exporter, enabling export of animations.
+        Displays collected camera in exporters.
+
     .. change:: changed
         :tags: definitions
 

--- a/hook/discover_houdini.py
+++ b/hook/discover_houdini.py
@@ -96,7 +96,6 @@ platform_options = {
 
 
 def on_discover_pipeline_houdini(session, event):
-
     from ftrack_connect_pipeline_houdini import (
         __version__ as integration_version,
     )

--- a/resource/bootstrap/python3.7libs/pythonrc.py
+++ b/resource/bootstrap/python3.7libs/pythonrc.py
@@ -142,7 +142,7 @@ def _open_widget(event_manager, asset_list_model, event):
     widget_name = None
     widget_class = None
     widget_label = None
-    for (_widget_name, _widget_class, _widget_label) in widgets:
+    for _widget_name, _widget_class, _widget_label in widgets:
         if _widget_name == event['data']['pipeline']['name']:
             widget_name = _widget_name
             widget_class = _widget_class

--- a/resource/bootstrap/python3.9libs/pythonrc.py
+++ b/resource/bootstrap/python3.9libs/pythonrc.py
@@ -142,7 +142,7 @@ def _open_widget(event_manager, asset_list_model, event):
     widget_name = None
     widget_class = None
     widget_label = None
-    for (_widget_name, _widget_class, _widget_label) in widgets:
+    for _widget_name, _widget_class, _widget_label in widgets:
         if _widget_name == event['data']['pipeline']['name']:
             widget_name = _widget_name
             widget_class = _widget_class

--- a/resource/definitions/publisher/camera-houdini-publish.json
+++ b/resource/definitions/publisher/camera-houdini-publish.json
@@ -65,7 +65,8 @@
           "plugins":[
             {
               "name": "Camera collector",
-              "plugin": "houdini_camera_publisher_collector"
+              "plugin": "houdini_camera_publisher_collector",
+              "widget": "houdini_camera_publisher_collector"
             }
           ]
         },
@@ -99,7 +100,8 @@
           "plugins":[
             {
               "name": "Camera Collector",
-              "plugin": "houdini_camera_publisher_collector"
+              "plugin": "houdini_camera_publisher_collector",
+              "widget": "houdini_camera_publisher_collector"
             }
           ]
         },
@@ -119,8 +121,7 @@
               "name": "Alembic exporter options:",
               "plugin": "houdini_abc_publisher_exporter",
               "options": {
-                "ABCAnimation": true,
-                "ABCFormat": ["Default","HDF5","Ogawa"]
+                "ABCAnimation": true
               }
             }
           ]
@@ -137,7 +138,8 @@
           "plugins":[
             {
               "name": "Camera Collector",
-              "plugin": "houdini_camera_publisher_collector"
+              "plugin": "houdini_camera_publisher_collector",
+              "widget": "houdini_camera_publisher_collector"
             }
           ]
         },

--- a/resource/definitions/publisher/geometry-houdini-publish.json
+++ b/resource/definitions/publisher/geometry-houdini-publish.json
@@ -66,7 +66,8 @@
           "plugins":[
             {
               "name": "Geometry Collector",
-              "plugin": "houdini_geometry_publisher_collector"
+              "plugin": "houdini_geometry_publisher_collector",
+              "widget": "houdini_geometry_publisher_collector"
             }
           ]
         },
@@ -100,7 +101,8 @@
           "plugins":[
             {
               "name": "Geometry Collector",
-              "plugin": "houdini_geometry_publisher_collector"
+              "plugin": "houdini_geometry_publisher_collector",
+              "widget": "houdini_geometry_publisher_collector"
             }
           ]
         },
@@ -118,11 +120,7 @@
           "plugins":[
             {
               "name": "Alembic exporter options:",
-              "plugin": "houdini_abc_publisher_exporter",
-              "options": {
-                "ABCAnimation": true,
-                "ABCFormat": ["Default","HDF5","Ogawa"]
-              }
+              "plugin": "houdini_abc_publisher_exporter"
             }
           ]
         }
@@ -138,7 +136,8 @@
           "plugins":[
             {
               "name": "Geometry Collector",
-              "plugin": "houdini_geometry_publisher_collector"
+              "plugin": "houdini_geometry_publisher_collector",
+              "widget": "houdini_geometry_publisher_collector"
             }
           ]
         },

--- a/resource/plugins/python/publisher/collectors/widget/houdini_camera_publisher_collector_options.py
+++ b/resource/plugins/python/publisher/collectors/widget/houdini_camera_publisher_collector_options.py
@@ -1,0 +1,51 @@
+# :coding: utf-8
+# :copyright: Copyright (c) 2014-2022 ftrack
+
+from ftrack_connect_pipeline_houdini import plugin
+from ftrack_connect_pipeline_qt.plugin.widget.base_collector_widget import (
+    BaseCollectorWidget,
+)
+
+import ftrack_api
+
+
+class HoudiniCameraPublisherCollectorOptionsWidget(BaseCollectorWidget):
+    # Run fetch function on widget initialization
+    auto_fetch_on_init = True
+
+    def __init__(
+        self,
+        parent=None,
+        session=None,
+        data=None,
+        name=None,
+        description=None,
+        options=None,
+        context_id=None,
+        asset_type_name=None,
+    ):
+        super(HoudiniCameraPublisherCollectorOptionsWidget, self).__init__(
+            parent=parent,
+            session=session,
+            data=data,
+            name=name,
+            description=description,
+            options=options,
+            context_id=context_id,
+            asset_type_name=asset_type_name,
+        )
+
+
+class HoudiniCameraPublisherCollectorPluginWidget(
+    plugin.HoudiniPublisherCollectorPluginWidget
+):
+    plugin_name = 'houdini_camera_publisher_collector'
+    widget = HoudiniCameraPublisherCollectorOptionsWidget
+
+
+def register(api_object, **kw):
+    if not isinstance(api_object, ftrack_api.Session):
+        # Exit to avoid registering this plugin again.
+        return
+    plugin = HoudiniCameraPublisherCollectorPluginWidget(api_object)
+    plugin.register()

--- a/resource/plugins/python/publisher/exporters/houdini_abc_publisher_exporter.py
+++ b/resource/plugins/python/publisher/exporters/houdini_abc_publisher_exporter.py
@@ -21,6 +21,7 @@ class HoudiniAbcPublisherExporterPlugin(plugin.HoudiniPublisherExporterPlugin):
     def extract_options(self, options):
         r = hou.playbar.frameRange()
         return {
+            'ABCFormat': str(options.get('ABCFormat', 'Default')),
             'ABCAnimation': bool(options.get('ABCAnimation', True)),
             'ABCFrameRangeStart': float(
                 options.get('ABCFrameRangeStart', r[0])
@@ -122,6 +123,9 @@ class HoudiniAbcPublisherExporterPlugin(plugin.HoudiniPublisherExporterPlugin):
             )
 
             abc_ropnet.render()
+        except Exception as e:
+            self.logger.exception(e)
+            return False, {'message': 'Failed to export Alembic: {}'.format(e)}
         finally:
             # Clean up after us
             if rop_net:

--- a/resource/plugins/python/publisher/exporters/houdini_fbx_publisher_exporter.py
+++ b/resource/plugins/python/publisher/exporters/houdini_fbx_publisher_exporter.py
@@ -85,50 +85,55 @@ class HoudiniFbxPublisherExporterPlugin(plugin.HoudiniPublisherExporterPlugin):
 
         object_paths = ' '.join(collected_objects)
         objects = [hou.node(obj_path) for obj_path in collected_objects]
-
-        # Create Rop Net
-        ropNet = root_obj.createNode('ropnet')
-        fbxRopnet = ropNet.createNode('filmboxfbx')
-
-        fbxRopnet.parm('trange').set(options['FBXValidFrameRange'])
-        fbxRopnet.parm('f1').set(options['FBXFrameRangeStart'])
-        fbxRopnet.parm('f2').set(options['FBXFrameRangeEnd'])
-        fbxRopnet.parm('f3').set(options['FBXFrameRangeBy'])
-        fbxRopnet.parm('take').set(options['FBXTake'])
-        fbxRopnet.parm('trange').set(options['FBXValidFrameRange'])
-        fbxRopnet.parm('sopoutput').set(new_file_path)
-        fbxRopnet.parm('startnode').set(objects[0].parent().path())
-        fbxRopnet.parm('exportkind').set(options['FBXASCII'])
-        fbxRopnet.parm('sdkversion').set(options['FBXSDKVersion'])
-        fbxRopnet.parm('vcformat').set(options['FBXVertexCacheFormat'])
-        fbxRopnet.parm('invisobj').set(options['FBXExportInvisibleObjects'])
-        fbxRopnet.parm('polylod').set(options['FBXConversionLevelOfDetail'])
-        fbxRopnet.parm('detectconstpointobjs').set(
-            options['FBXDetectConstantPointCountDynamicObjects']
-        )
-        fbxRopnet.parm('convertsurfaces').set(
-            options['FBXConvertNURBSAndBeizerSurfaceToPolygons']
-        )
-        fbxRopnet.parm('conservemem').set(
-            options['FBXConserveMemoryAtTheExpenseOfExportTime']
-        )
-        fbxRopnet.parm('forceblendshape').set(
-            options['FBXForceBlendShapeExport']
-        )
-        fbxRopnet.parm('forceskindeform').set(
-            options['FBXForceSkinDeformExport']
-        )
+        ropNet = None
         try:
+            # Create Rop Net
+            ropNet = root_obj.createNode('ropnet')
+            fbxRopnet = ropNet.createNode('filmboxfbx')
+
+            fbxRopnet.parm('trange').set(options['FBXValidFrameRange'])
+            fbxRopnet.parm('f1').set(options['FBXFrameRangeStart'])
+            fbxRopnet.parm('f2').set(options['FBXFrameRangeEnd'])
+            fbxRopnet.parm('f3').set(options['FBXFrameRangeBy'])
+            fbxRopnet.parm('take').set(options['FBXTake'])
+            fbxRopnet.parm('trange').set(options['FBXValidFrameRange'])
+            fbxRopnet.parm('sopoutput').set(new_file_path)
+            fbxRopnet.parm('startnode').set(objects[0].parent().path())
+            fbxRopnet.parm('exportkind').set(options['FBXASCII'])
+            fbxRopnet.parm('sdkversion').set(options['FBXSDKVersion'])
+            fbxRopnet.parm('vcformat').set(options['FBXVertexCacheFormat'])
+            fbxRopnet.parm('invisobj').set(
+                options['FBXExportInvisibleObjects']
+            )
+            fbxRopnet.parm('polylod').set(
+                options['FBXConversionLevelOfDetail']
+            )
+            fbxRopnet.parm('detectconstpointobjs').set(
+                options['FBXDetectConstantPointCountDynamicObjects']
+            )
+            fbxRopnet.parm('convertsurfaces').set(
+                options['FBXConvertNURBSAndBeizerSurfaceToPolygons']
+            )
+            fbxRopnet.parm('conservemem').set(
+                options['FBXConserveMemoryAtTheExpenseOfExportTime']
+            )
+            fbxRopnet.parm('forceblendshape').set(
+                options['FBXForceBlendShapeExport']
+            )
+            fbxRopnet.parm('forceskindeform').set(
+                options['FBXForceSkinDeformExport']
+            )
             fbxRopnet.parm('axissystem').set(options['FBXAxisSystem'])
             fbxRopnet.parm('exportendeffectors').set(
                 options['FBXExportEndEffectors']
             )
-        except:
-            pass  # Not supported in older versions
-        try:
             fbxRopnet.render()
+        except Exception as e:
+            self.logger.exception(e)
+            return False, {'message': 'Failed to export Alembic: {}'.format(e)}
         finally:
-            ropNet.destroy()
+            if ropNet:
+                ropNet.destroy()
 
         return [new_file_path]
 

--- a/resource/plugins/python/publisher/exporters/houdini_native_publisher_exporter.py
+++ b/resource/plugins/python/publisher/exporters/houdini_native_publisher_exporter.py
@@ -14,7 +14,6 @@ import ftrack_api
 class HoudiniNativePublisherExporterPlugin(
     plugin.HoudiniPublisherExporterPlugin
 ):
-
     plugin_name = 'houdini_native_publisher_exporter'
 
     extension = '.hip'

--- a/resource/plugins/python/publisher/exporters/widget/houdini_abc_publisher_exporter_options.py
+++ b/resource/plugins/python/publisher/exporters/widget/houdini_abc_publisher_exporter_options.py
@@ -46,10 +46,10 @@ class HoudiniAbcPublisherExporterOptionsWidget(DynamicWidget):
     def on_fetch_callback(self, result):
         '''This function is called by the _set_internal_run_result function of
         the BaseOptionsWidget'''
-        self._get_widget('ABCFrameRangeStart').setText(
-            str(result['frameStart'])
-        )
-        self._get_widget('ABCFrameRangeEnd').setText(str(result['frameEnd']))
+        #self._get_widget('ABCFrameRangeStart').setText(
+        #    str(result['frameStart'])
+        #)
+        #self._get_widget('ABCFrameRangeEnd').setText(str(result['frameEnd']))
 
     def get_options_group_name(self):
         '''Override'''

--- a/resource/plugins/python/publisher/exporters/widget/houdini_abc_publisher_exporter_options.py
+++ b/resource/plugins/python/publisher/exporters/widget/houdini_abc_publisher_exporter_options.py
@@ -1,41 +1,15 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2021 ftrack
-
-from functools import partial
-
-from ftrack_connect_pipeline_houdini import plugin
-from ftrack_connect_pipeline_qt.plugin.widget import BaseOptionsWidget
-
-
-from Qt import QtWidgets
+# :copyright: Copyright (c) 2014-2023 ftrack
 
 import ftrack_api
 
+from ftrack_connect_pipeline_houdini import plugin
+from ftrack_connect_pipeline_qt.plugin.widget.dynamic import DynamicWidget
 
-class HoudiniAbcPublisherExporterOptionsWidget(BaseOptionsWidget):
+
+class HoudiniAbcPublisherExporterOptionsWidget(DynamicWidget):
+
     auto_fetch_on_init = True
-    OPTIONS = {
-        'ABCAnimation': {
-            'type': 'checkbox',
-            'label': 'Include animation',
-            'default': True,
-        },
-        'ABCFrameRangeStart': {
-            'type': 'line',
-            'label': 'Frame range start',
-            'default_option': 'frameStart',
-        },
-        'ABCFrameRangeEnd': {
-            'type': 'line',
-            'label': 'Frame range end',
-            'default_option': 'frameEnd',
-        },
-        'ABCFrameRangeBy': {
-            'type': 'line',
-            'label': 'Evaluate every',
-            'default': '1.0',
-        },
-    }
 
     def __init__(
         self,
@@ -48,8 +22,6 @@ class HoudiniAbcPublisherExporterOptionsWidget(BaseOptionsWidget):
         context_id=None,
         asset_type_name=None,
     ):
-        self.widgets = {}
-
         super(HoudiniAbcPublisherExporterOptionsWidget, self).__init__(
             parent=parent,
             session=session,
@@ -61,83 +33,40 @@ class HoudiniAbcPublisherExporterOptionsWidget(BaseOptionsWidget):
             asset_type_name=asset_type_name,
         )
 
+    def define_options(self):
+        '''Default renderable options for dynamic widget'''
+        return {
+            "ABCFormat": ["Default", "HDF5", "Ogawa"],
+            "ABCAnimation": False,
+            "ABCFrameRangeStart": "1.0",
+            "ABCFrameRangeEnd": "100.0",
+            "ABCFrameRangeBy": "1.0",
+        }
+
     def on_fetch_callback(self, result):
         '''This function is called by the _set_internal_run_result function of
         the BaseOptionsWidget'''
+        self._get_widget('ABCFrameRangeStart').setText(
+            str(result['frameStart'])
+        )
+        self._get_widget('ABCFrameRangeEnd').setText(str(result['frameEnd']))
+
+    def get_options_group_name(self):
+        '''Override'''
+        return 'Alembic exporter options'
 
     def build(self):
         '''build function , mostly used to create the widgets.'''
+
+        self.update(self.define_options())
+
         super(HoudiniAbcPublisherExporterOptionsWidget, self).build()
-
-        for name, option in self.OPTIONS.items():
-            default = None
-
-            if option['type'] == 'checkbox':
-                self.layout().addWidget(QtWidgets.QLabel(option['label']))
-                widget = QtWidgets.QCheckBox(option['label'])
-            elif option['type'] == 'combobox':
-                self.layout().addWidget(QtWidgets.QLabel(option['label']))
-                widget = QtWidgets.QComboBox()
-                for item in option['options']:
-                    widget.addItem(item['label'])
-            elif option['type'] == 'line':
-                widget = QtWidgets.QLineEdit()
-
-            self.widgets[name] = widget
-            self.layout().addWidget(widget)
-
-    def current_index_changed(self, name, label):
-        for item in self.OPTIONS[name]['options']:
-            if item['label'] == label:
-                self.set_option_result(item['value'], name)
-
-    def post_build(self):
-        super(HoudiniAbcPublisherExporterOptionsWidget, self).post_build()
-
-        for name, widget in self.widgets.items():
-            option = self.OPTIONS[name]
-
-            if name in self.options:
-                default = self.options[name]
-            else:
-                default_option = option.get('default_option')
-                default = None
-                if 0 < len(default_option or ''):
-                    # Replace with that option's current value
-                    default = self.options[default_option]
-                if len(default or '') == 0:
-                    default = option.get('default')
-
-            update_fn = partial(self.set_option_result, key=name)
-            if option['type'] == 'checkbox':
-                if default is not None:
-                    widget.setChecked(default)
-                widget.stateChanged.connect(update_fn)
-            elif self.OPTIONS[name]['type'] == 'combobox':
-                if default is not None:
-                    idx = 0
-                    for item in option['options']:
-                        if (
-                            item['value'] == default
-                            or item['label'] == default
-                        ):
-                            widget.setCurrentIndex(idx)
-                        idx += 1
-                update_fn = partial(self.current_index_changed, name)
-                widget.currentIndexChanged.connect(update_fn)
-            elif option['type'] == 'line':
-                if default is not None:
-                    widget.setText(default)
-                widget.textChanged.connect(update_fn)
-
-    def _reset_default_animation_options(self):
-        pass
 
 
 class HoudiniAbcPublisherExporterOptionsPluginWidget(
     plugin.HoudiniPublisherExporterPluginWidget
 ):
-    plugin_name = 'houdini_abc_publisher_exporter_options'
+    plugin_name = 'houdini_abc_publisher_exporter'
     widget = HoudiniAbcPublisherExporterOptionsWidget
 
 

--- a/resource/plugins/python/publisher/exporters/widget/houdini_fbx_publisher_exporter_options.py
+++ b/resource/plugins/python/publisher/exporters/widget/houdini_fbx_publisher_exporter_options.py
@@ -1,93 +1,16 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2021 ftrack
-
-from functools import partial
+# :copyright: Copyright (c) 2014-2023 ftrack
 
 from ftrack_connect_pipeline_houdini import plugin
 from ftrack_connect_pipeline_qt.plugin.widget.dynamic import DynamicWidget
 
-from Qt import QtWidgets
-
 import ftrack_api
-
-OPTIONS = {
-    'FBXASCII': {'type': 'checkbox', 'label': 'ASCII Format', 'default': True},
-    'FBXSDKVersion': {
-        'type': 'combobox',
-        'label': 'FBX SDK Version',
-        'options': [
-            {'label': 'FBX | FBX201600', 'value': 'FBX | FBX201600'},
-            {'label': 'FBX | FBX201400', 'value': 'FBX | FBX201400'},
-            {'label': 'FBX | FBX201300', 'value': 'FBX | FBX201300'},
-            {'label': 'FBX | FBX201200', 'value': 'FBX | FBX201200'},
-            {'label': 'FBX | FBX201100', 'value': 'FBX | FBX201100'},
-            {'label': 'FBX 6.0 | FBX201000', 'value': 'FBX 6.0 | FBX201000'},
-            {'label': 'FBX 6.0 | FBX200900', 'value': 'FBX 6.0 | FBX200900'},
-            {'label': 'FBX 6.0 | FBX200611', 'value': 'FBX 6.0 | FBX200611'},
-        ],
-    },
-    'FBXVertexCacheFormat': {
-        'type': 'combobox',
-        'label': 'Vertex Cache Format',
-        'options': [
-            {'label': 'Maya Compatible (MC)', 'value': 'mayaformat'},
-            {'label': '3DS Max Compatible (PC2)', 'value': 'maxformat'},
-        ],
-    },
-    'FBXExportInvisibleObjects': {
-        'type': 'combobox',
-        'label': 'Export Invisible Objects',
-        'options': [
-            {'label': 'As hidden null nodes', 'value': 'nullnodes'},
-            {'label': 'As hidden full nodes', 'value': 'fullnodes'},
-            {'label': 'As visible full nodes', 'value': 'visiblenodes'},
-            {'label': 'Dont export', 'value': 'nonodes'},
-        ],
-    },
-    'FBXAxisSystem': {
-        'type': 'combobox',
-        'label': 'Axis system',
-        'options': [
-            {'label': 'Y Up (Right-handed)', 'value': 'yupright'},
-            {'label': 'Y Up (Left-handed)', 'value': 'yupleft'},
-            {'label': 'Z Up (Right-handed)', 'value': 'zupright'},
-            {'label': 'Current (Y up Right-handed)', 'value': 'currentup'},
-        ],
-    },
-    'FBXConversionLevelOfDetail': {
-        'type': 'line',
-        'label': 'Conversion Level of Detail',
-        'default': '1.0',
-    },
-    'FBXDetectConstantPointCountDynamicObjects': {
-        'type': 'checkbox',
-        'label': 'Detect Constant Point Count Dynamic Objects',
-    },
-    'FBXConvertNURBSAndBeizerSurfaceToPolygons': {
-        'type': 'checkbox',
-        'label': 'Convert NURBS and Beizer Surface to Polygons',
-    },
-    'FBXConserveMemoryAtTheExpenseOfExportTime': {
-        'type': 'checkbox',
-        'label': 'Conserve Memory at the Expense of Export Time',
-    },
-    'FBXForceBlendShapeExport': {
-        'type': 'checkbox',
-        'label': 'Force Blend Shape Export',
-    },
-    'FBXForceSkinDeformExport': {
-        'type': 'checkbox',
-        'label': 'Force Skin Deform Export',
-    },
-    'FBXExportEndEffectors': {
-        'type': 'checkbox',
-        'label': 'Export End Effectors',
-        'default': True,
-    },
-}
 
 
 class HoudiniFbxPublisherExporterOptionsWidget(DynamicWidget):
+
+    auto_fetch_on_init = True
+
     def __init__(
         self,
         parent=None,
@@ -99,9 +22,6 @@ class HoudiniFbxPublisherExporterOptionsWidget(DynamicWidget):
         context_id=None,
         asset_type_name=None,
     ):
-
-        self.widgets = {}
-
         super(HoudiniFbxPublisherExporterOptionsWidget, self).__init__(
             parent=parent,
             session=session,
@@ -113,70 +33,75 @@ class HoudiniFbxPublisherExporterOptionsWidget(DynamicWidget):
             asset_type_name=asset_type_name,
         )
 
+    def define_options(self):
+        '''Default renderable options for dynamic widget'''
+        return {
+            'FBXASCII': True,
+            "FBXValidFrameRange": [
+                {"label": "Current frame", "value": 0},
+                {"label": "Render frame range", "value": 1},
+                {"label": "Render frame range only (strict)", "value": 2},
+            ],
+            "FBXFrameRangeStart": "1.0",
+            "FBXFrameRangeEnd": "100.0",
+            "FBXFrameRangeBy": "1.0",
+            "FBXTake": "_current_",
+            'FBXSDKVersion': [
+                {'value': 'FBX | FBX202000', "default": True},
+                {'value': 'FBX | FBX201900'},
+                {'value': 'FBX | FBX201800'},
+                {'value': 'FBX | FBX201600'},
+                {'value': 'FBX | FBX201400'},
+                {'value': 'FBX | FBX201300'},
+                {'value': 'FBX | FBX201200'},
+                {'value': 'FBX | FBX201100'},
+                {'value': 'FBX 6.0 | FBX201000'},
+                {'value': 'FBX 6.0 | FBX200900'},
+                {'value': 'FBX 6.0 | FBX200611'},
+            ],
+            'FBXVertexCacheFormat': [
+                {'label': 'Maya Compatible (MC)', 'value': 'mayaformat'},
+                {'label': '3DS Max Compatible (PC2)', 'value': 'maxformat'},
+            ],
+            'FBXExportInvisibleObjects': [
+                {'label': 'As hidden null nodes', 'value': 'nullnodes'},
+                {'label': 'As hidden full nodes', 'value': 'fullnodes'},
+                {'label': 'As visible full nodes', 'value': 'visiblenodes'},
+                {'label': 'Dont export', 'value': 'nonodes'},
+            ],
+            'FBXAxisSystem': [
+                {'label': 'Y Up (Right-handed)', 'value': 'yupright'},
+                {'label': 'Y Up (Left-handed)', 'value': 'yupleft'},
+                {'label': 'Z Up (Right-handed)', 'value': 'zupright'},
+                {'label': 'Current (Y up Right-handed)', 'value': 'currentup'},
+            ],
+            'FBXConversionLevelOfDetail': "1.0",
+            'FBXDetectConstantPointCountDynamicObjects': False,
+            'FBXConvertNURBSAndBeizerSurfaceToPolygons': False,
+            'FBXConserveMemoryAtTheExpenseOfExportTime': False,
+            'FBXForceBlendShapeExport': False,
+            'FBXForceSkinDeformExport': False,
+            'FBXExportEndEffectors': True,
+        }
+
+    def get_options_group_name(self):
+        '''Override'''
+        return 'FBX exporter options'
+
     def build(self):
         '''build function , mostly used to create the widgets.'''
+
+        self.update(self.define_options())
+
         super(HoudiniFbxPublisherExporterOptionsWidget, self).build()
 
-        for name, option in OPTIONS.items():
-            default = None
-
-            if option['type'] == 'checkbox':
-                widget = QtWidgets.QCheckBox(option['label'])
-            elif option['type'] == 'combobox':
-                self.layout().addWidget(QtWidgets.QLabel(option['label']))
-                widget = QtWidgets.QComboBox()
-                for item in option['options']:
-                    widget.addItem(item['label'])
-            elif option['type'] == 'line':
-                self.layout().addWidget(QtWidgets.QLabel(option['label']))
-                widget = QtWidgets.QLineEdit()
-
-            self.widgets[name] = widget
-            self.layout().addWidget(widget)
-
-    def current_index_changed(self, name, label):
-        for item in self.OPTIONS[name]['options']:
-            if item['label'] == label:
-                self.set_option_result(item['value'], name)
-
-    def post_build(self):
-        super(HoudiniFbxPublisherExporterOptionsWidget, self).post_build()
-
-        for name, widget in self.widgets.items():
-            option = OPTIONS[name]
-
-            if name in self.options:
-                default = self.options[name]
-            else:
-                default_option = option.get('default_option')
-                default = None
-                if 0 < len(default_option or ''):
-                    # Replace with that option's current value
-                    default = self.options[default_option]
-                if len(default or '') == 0:
-                    default = option.get('default')
-
-            update_fn = partial(self.set_option_result, key=name)
-            if option['type'] == 'checkbox':
-                if default is not None:
-                    widget.setChecked(default)
-                widget.stateChanged.connect(update_fn)
-            elif OPTIONS[name]['type'] == 'combobox':
-                if default is not None:
-                    idx = 0
-                    for item in option['options']:
-                        if (
-                            item['value'] == default
-                            or item['label'] == default
-                        ):
-                            widget.setCurrentIndex(idx)
-                        idx += 1
-                update_fn = partial(self.current_index_changed, name)
-                widget.currentIndexChanged.connect(update_fn)
-            elif option['type'] == 'line':
-                if default is not None:
-                    widget.setText(default)
-                widget.textChanged.connect(update_fn)
+    def on_fetch_callback(self, result):
+        '''This function is called by the _set_internal_run_result function of
+        the BaseOptionsWidget'''
+        self._get_widget('FBXFrameRangeStart').setText(
+            str(result['frameStart'])
+        )
+        self._get_widget('FBXFrameRangeEnd').setText(str(result['frameEnd']))
 
 
 class HoudiniFbxPublisherExporterOptionsPluginWidget(

--- a/resource/plugins/python/publisher/exporters/widget/houdini_fbx_publisher_exporter_options.py
+++ b/resource/plugins/python/publisher/exporters/widget/houdini_fbx_publisher_exporter_options.py
@@ -98,10 +98,10 @@ class HoudiniFbxPublisherExporterOptionsWidget(DynamicWidget):
     def on_fetch_callback(self, result):
         '''This function is called by the _set_internal_run_result function of
         the BaseOptionsWidget'''
-        self._get_widget('FBXFrameRangeStart').setText(
-            str(result['frameStart'])
-        )
-        self._get_widget('FBXFrameRangeEnd').setText(str(result['frameEnd']))
+        #self._get_widget('FBXFrameRangeStart').setText(
+        #    str(result['frameStart'])
+        #)
+        #self._get_widget('FBXFrameRangeEnd').setText(str(result['frameEnd']))
 
 
 class HoudiniFbxPublisherExporterOptionsPluginWidget(

--- a/resource/plugins/python/publisher/exporters/widget/houdini_native_publisher_exporter_options.py
+++ b/resource/plugins/python/publisher/exporters/widget/houdini_native_publisher_exporter_options.py
@@ -24,7 +24,6 @@ class HoudiniDefaultPublisherExporterOptionsWidget(DynamicWidget):
         context_id=None,
         asset_type_name=None,
     ):
-
         self.options_cb = {}
 
         super(HoudiniDefaultPublisherExporterOptionsWidget, self).__init__(

--- a/source/ftrack_connect_pipeline_houdini/utils/__init__.py
+++ b/source/ftrack_connect_pipeline_houdini/utils/__init__.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 import hdefereval
 
+
 def run_in_main_thread(f):
     '''Make sure a function runs in the main Maya thread.'''
 
@@ -16,6 +17,7 @@ def run_in_main_thread(f):
             return f(*args, **kwargs)
 
     return decorated
+
 
 from ftrack_connect_pipeline_houdini.utils.bootstrap import *
 from ftrack_connect_pipeline_houdini.utils.file import *

--- a/source/ftrack_connect_pipeline_houdini/utils/bootstrap.py
+++ b/source/ftrack_connect_pipeline_houdini/utils/bootstrap.py
@@ -6,6 +6,8 @@ import logging
 import hou
 
 logger = logging.getLogger(__name__)
+
+
 def init_houdini(context_id=None, session=None):
     '''
     Initialise timeline in Houdini based on shot/asset build metadata.
@@ -73,5 +75,3 @@ def init_houdini(context_id=None, session=None):
     if fps is not None:
         logger.info('Setting FPS : {}'.format(fps))
         hou.setFps(fps)
-
-

--- a/source/ftrack_connect_pipeline_houdini/utils/file.py
+++ b/source/ftrack_connect_pipeline_houdini/utils/file.py
@@ -5,6 +5,7 @@ import hou
 
 from ftrack_connect_pipeline import utils as core_utils
 
+
 def import_scene(path, context_data=None, options=None):
     '''
     Import the scene from the given *path*, *context_data* and *options*.
@@ -16,6 +17,7 @@ def import_scene(path, context_data=None, options=None):
     node.moveToGoodPosition()
 
     return node
+
 
 def merge_scene(path, context_data=None, options=None):
     '''

--- a/source/ftrack_connect_pipeline_houdini/utils/node.py
+++ b/source/ftrack_connect_pipeline_houdini/utils/node.py
@@ -5,6 +5,7 @@ import hou, hdefereval
 
 from ftrack_connect_pipeline_houdini.constants import asset as asset_const
 
+
 def get_current_scene_objects():
     '''Return all objects within the houdini scene'''
     return set(hou.node('/obj').glob('*'))
@@ -39,4 +40,3 @@ def get_connected_objects(name):
                 if linked_ftrack_node_name == name:
                     result.append(node)
     return result
-


### PR DESCRIPTION
<!--(https://github.com/ftrackhq/ftrack-connect-pipeline-houdini/compare/next...backlog/fix-houdini-exporters?expand=1
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-865by8m8c

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Fixed UI bugs in Alembic and FBX exporter
- Added frame range and take options to FBX exporter, enabling export of animations
- Displays collected camera in exporter


## Test

_Note: needs to be tested on corresponding branches on QT and Houdini._

Test FBX and Alembic export, with geometry and camera publishers. Validate UI options and validate the results in other DCC.
            